### PR TITLE
Don't rely on empty names to detect anonymous items.

### DIFF
--- a/com-scrape/src/clang.rs
+++ b/com-scrape/src/clang.rs
@@ -146,6 +146,10 @@ impl<'a> Cursor<'a> {
         unsafe { StringRef::from_raw(clang_getCursorSpelling(self.cursor)) }
     }
 
+    pub fn is_anonymous(&self) -> bool {
+        unsafe { clang_Cursor_isAnonymous(self.cursor) != 0 }
+    }
+
     pub fn location(&self) -> Location<'a> {
         unsafe { Location::from_raw(clang_getCursorLocation(self.cursor)) }
     }

--- a/com-scrape/src/print.rs
+++ b/com-scrape/src/print.rs
@@ -167,14 +167,15 @@ impl<'a, W: Write> RustPrinter<'a, W> {
 
         let mut anon_counter = 0;
         for field in &record.fields {
-            let field_name = &field.name;
-            if field.name.is_empty() {
+            if let Some(field_name) = &field.name {
+                if self.reserved.contains(&**field_name) {
+                    write!(self.sink, "{indent}    pub r#{field_name}: ")?;
+                } else {
+                    write!(self.sink, "{indent}    pub {field_name}: ")?;
+                }
+            } else {
                 write!(self.sink, "{indent}    pub __field{anon_counter}: ")?;
                 anon_counter += 1;
-            } else if self.reserved.contains(&*field.name) {
-                write!(self.sink, "{indent}    pub r#{field_name}: ")?;
-            } else {
-                write!(self.sink, "{indent}    pub {field_name}: ")?;
             }
             self.print_type(&field.type_)?;
             writeln!(self.sink, ",")?;


### PR DESCRIPTION
Currently, we detect anonymous items by checking if their name is an empty string, but newer versions of libclang return names like "(anonymous enum at ...)" in this case. Use clang_Cursor_isAnonymous instead to detect anonymous items explicitly.

Fixes #1.