### PR TITLE
Use runtime clang-sys feature to match cpal

### DIFF
--- a/com-scrape/Cargo.toml
+++ b/com-scrape/Cargo.toml
@@ -8,4 +8,4 @@ repository = "https://github.com/coupler-rs/vst3-bindgen"
 license = "MIT OR Apache-2.0"
 
 [dependencies]
-clang-sys = { version = "1", features = ["clang_6_0"] }
+clang-sys = { version = "1", features = ["clang_6_0", "runtime"] }

--- a/com-scrape/src/generator.rs
+++ b/com-scrape/src/generator.rs
@@ -127,6 +127,9 @@ impl Generator {
     }
 
     pub fn generate<W: Write>(&self, sink: W) -> Result<(), Box<dyn Error>> {
+        if !clang_sys::is_loaded() {
+            clang_sys::load()?;
+        }
         let mut clang_target = None;
         if let Ok(target) = env::var("TARGET") {
             if target != HOST_TARGET {


### PR DESCRIPTION
I was getting the following `clang-sys` failure when using `vst3-bindgen` in a crate that also depends on `cpal`:

```
  thread 'main' panicked at 'a `libclang` shared library is not loaded on this thread', /Users/kevin/.cargo/registry/src/index.crates.io-6f17d22bba15001f/clang-sys-1.6.1/src/lib.rs:1735:1
```

I think `cpal`'s transitive dependency on `clang-sys` enables the runtime feature, also enabling it for `com-scrape`'s usage of `clang-sys`. But `clang_sys::load()` must be called when the runtime feature is enabled.

We could in theory expose the `clang-sys/runtime` feature through `vst3_bindgen -> com-scrape -> clang-sys` if we don't always want it enabled, let me know what you think.