### PR TITLE
Add `ComWrapperWeak`

### DIFF
--- a/com-scrape-types/src/class.rs
+++ b/com-scrape-types/src/class.rs
@@ -1,6 +1,6 @@
 use std::ops::Deref;
 use std::ptr::addr_of;
-use std::sync::Arc;
+use std::sync::{Arc, Weak};
 
 use super::{ComPtr, ComRef, Guid, Interface};
 
@@ -295,5 +295,54 @@ impl<C: Class> ComWrapper<C> {
         } else {
             None
         }
+    }
+
+    /// Creates a [`ComWrapperWeak`] to this object.
+    #[inline]
+    pub fn downgrade(&self) -> ComWrapperWeak<C> {
+        ComWrapperWeak {
+            inner: Arc::downgrade(&self.inner),
+        }
+    }
+}
+
+/// Weak version of [`ComWrapper`], which holds a non-owning reference to the COM object.
+///
+/// The underlying object can be accessed by calling [`ComWrapperWeak::upgrade`], which will return `None` if the object has already been dropped.
+///
+/// See [`Weak`] for more information on weak references.
+pub struct ComWrapperWeak<C: Class> {
+    inner: Weak<ComWrapperInner<C>>,
+}
+
+impl<C: Class> Clone for ComWrapperWeak<C> {
+    fn clone(&self) -> ComWrapperWeak<C> {
+        ComWrapperWeak {
+            inner: self.inner.clone(),
+        }
+    }
+}
+
+impl<C: Class> Default for ComWrapperWeak<C> {
+    fn default() -> ComWrapperWeak<C> {
+        ComWrapperWeak::new()
+    }
+}
+
+impl<C: Class> ComWrapperWeak<C> {
+    /// Construct a new [`ComWrapperWeak`] without allocating any memory.
+    ///
+    /// Calling [`ComWrapperWeak::upgrade`] on the returned value will always return `None`.
+    #[inline]
+    pub fn new() -> ComWrapperWeak<C> {
+        ComWrapperWeak { inner: Weak::new() }
+    }
+
+    /// Attempts to upgrade the weak reference to a strong reference, delaying dropping of the inner value if successful.
+    ///
+    /// Returns `None` if the inner value has already been dropped.
+    #[inline]
+    pub fn upgrade(&self) -> Option<ComWrapper<C>> {
+        self.inner.upgrade().map(|inner| ComWrapper { inner })
     }
 }

--- a/com-scrape-types/src/class.rs
+++ b/com-scrape-types/src/class.rs
@@ -318,9 +318,9 @@ impl<C: Class> ComWrapper<C> {
 
     /// Creates a [`ComWrapperWeak`] to this object.
     #[inline]
-    pub fn downgrade(&self) -> ComWrapperWeak<C> {
+    pub fn downgrade(this: &Self) -> ComWrapperWeak<C> {
         ComWrapperWeak {
-            inner: Arc::downgrade(&self.inner),
+            inner: Arc::downgrade(&this.inner),
         }
     }
 }

--- a/com-scrape-types/src/class.rs
+++ b/com-scrape-types/src/class.rs
@@ -315,6 +315,9 @@ pub struct ComWrapperWeak<C: Class> {
     inner: Weak<ComWrapperInner<C>>,
 }
 
+unsafe impl<C: Class> Send for ComWrapperWeak<C> where C: Send + Sync {}
+unsafe impl<C: Class> Sync for ComWrapperWeak<C> where C: Send + Sync {}
+
 impl<C: Class> Clone for ComWrapperWeak<C> {
     fn clone(&self) -> ComWrapperWeak<C> {
         ComWrapperWeak {

--- a/com-scrape-types/src/class.rs
+++ b/com-scrape-types/src/class.rs
@@ -261,6 +261,25 @@ impl<C: Class> ComWrapper<C> {
         }
     }
 
+    /// Constructs a new [`ComWrapper`] with a cyclic reference to itself.
+    ///
+    /// See [`Arc::new_cyclic`] for more information.
+    #[inline]
+    pub fn new_cyclic(data: impl FnOnce(ComWrapperWeak<C>) -> C) -> ComWrapper<C>
+    where
+        C: 'static,
+        C::Interfaces: MakeHeader<C, Self>,
+    {
+        ComWrapper {
+            inner: Arc::new_cyclic(|weak| ComWrapperInner {
+                header: C::Interfaces::HEADER,
+                data: data(ComWrapperWeak {
+                    inner: weak.clone(),
+                }),
+            }),
+        }
+    }
+
     /// If `I` is in `C`'s interface list, returns a [`ComRef<I>`] pointing to the object.
     ///
     /// Does not perform any reference counting operations.

--- a/com-scrape-types/src/lib.rs
+++ b/com-scrape-types/src/lib.rs
@@ -91,7 +91,9 @@ mod tests;
 
 use std::ffi::c_void;
 
-pub use class::{Class, ComWrapper, Construct, Header, InterfaceList, MakeHeader, Wrapper};
+pub use class::{
+    Class, ComWrapper, ComWrapperWeak, Construct, Header, InterfaceList, MakeHeader, Wrapper,
+};
 pub use ptr::{ComPtr, ComRef, SmartPtr};
 
 /// A 16-byte unique identifier for a COM interface.

--- a/com-scrape-types/src/tests.rs
+++ b/com-scrape-types/src/tests.rs
@@ -3,6 +3,7 @@ use std::ffi::{c_long, c_ulong, c_void};
 use std::ptr;
 use std::rc::Rc;
 
+use crate::class::ComWrapperWeak;
 use crate::*;
 
 #[repr(C)]
@@ -488,4 +489,43 @@ fn com_wrapper() {
 
     drop(com_ptr_4);
     assert_eq!(dropped.get(), true);
+}
+
+#[test]
+fn com_wrapper_weak() {
+    let dropped = Rc::new(Cell::new(false));
+    let obj = ComWrapper::new(MyClass2 {
+        x: 1,
+        y: 2,
+        dropped: dropped.clone(),
+    });
+
+    let weak = obj.downgrade();
+    assert!(!dropped.get());
+
+    let upgraded = weak.upgrade().unwrap();
+    assert_eq!(
+        upgraded.as_com_ref::<IMyInterface>().unwrap().my_method(),
+        1
+    );
+    assert_eq!(
+        upgraded
+            .as_com_ref::<IOtherInterface>()
+            .unwrap()
+            .other_method(),
+        2
+    );
+
+    drop(obj);
+    assert!(!dropped.get());
+
+    drop(upgraded);
+    assert!(dropped.get());
+
+    let after_drop = weak.upgrade();
+    assert!(after_drop.is_none());
+
+    let dangling = ComWrapperWeak::<MyClass2>::new();
+    let dangling = dangling.upgrade();
+    assert!(dangling.is_none());
 }

--- a/com-scrape-types/src/tests.rs
+++ b/com-scrape-types/src/tests.rs
@@ -3,7 +3,6 @@ use std::ffi::{c_long, c_ulong, c_void};
 use std::ptr;
 use std::rc::Rc;
 
-use crate::class::ComWrapperWeak;
 use crate::*;
 
 #[repr(C)]

--- a/com-scrape-types/src/tests.rs
+++ b/com-scrape-types/src/tests.rs
@@ -499,7 +499,7 @@ fn com_wrapper_weak() {
         dropped: dropped.clone(),
     });
 
-    let weak = obj.downgrade();
+    let weak = ComWrapper::downgrade(&obj);
     assert!(!dropped.get());
 
     let upgraded = weak.upgrade().unwrap();


### PR DESCRIPTION
Adds `ComWrapperWeak` which is a `std::sync::Weak`-based weak reference alternative to `ComWrapper`.